### PR TITLE
Change default beam energy to 10.5473 GeV

### DIFF
--- a/lib/rge_filename_handler.h
+++ b/lib/rge_filename_handler.h
@@ -37,6 +37,7 @@ typedef long int lint;
 #define RGE_BE12016 10.3894 /** 250 nA. */
 #define RGE_BE12439  2.1864 /**  15 nA. */
 #define RGE_BE12933 10.4057 /** 250 nA. */
+#define RGE_BE 10.5473
 
 /**
  * Get run number from a filename, assuming the filename is in format

--- a/src/rge_filename_handler.c
+++ b/src/rge_filename_handler.c
@@ -63,8 +63,8 @@ int get_beam_energy(int run_no, double *beam_energy) {
             *beam_energy = RGE_BE12933;
             break;
         default:
-            rge_errno = RGEERR_UNIMPLEMENTEDBEAMENERGY;
-            return 1;
+            *beam_energy = RGE_BE;
+            break;
     }
 
     return 0;


### PR DESCRIPTION
Instead of choosing a beam energy based on the run number, the default beam energy will now be 10.5473 GeV, which is based on the energies in the [RCDB](https://clasweb.jlab.org/rcdb).