### PR TITLE
Fix charge variable and add a trigger status variable

### DIFF
--- a/lib/rge_constants.h
+++ b/lib/rge_constants.h
@@ -79,7 +79,7 @@ const RGE_VAR RGE_P      = {.addr = 13, .name = "p"}; // Unit: GeV
 const RGE_VAR RGE_THETA  = {.addr = 14, .name = "theta"}; // Unit: rad
 const RGE_VAR RGE_PHI    = {.addr = 15, .name = "phi"};  // Unit: rad
 const RGE_VAR RGE_BETA   = {.addr = 16, .name = "beta"};
-const RGE_VAR RGE_TRIGGERSTATUS   = {.addr = 17, .name = "trigger_status"};
+const RGE_VAR RGE_TRIGGERSTATUS   = {.addr = 17, .name = "trigger_status"}; // 0 if particle is not the trigger electron, 1 if particle is the trigger electron
 
 /** Tracking variables. */
 const RGE_VAR RGE_CHI2 = {.addr = 18, .name = "chi2"};

--- a/lib/rge_constants.h
+++ b/lib/rge_constants.h
@@ -56,7 +56,7 @@ typedef struct {
 #define RGE_VZHIGHCUT   26.1197 /** vz must be below this. */
 
 /** Variable array data. */
-#define RGE_VARS_SIZE 36
+#define RGE_VARS_SIZE 37
 extern const char *RGE_VARS[RGE_VARS_SIZE];
 
 /** Metadata variables. */
@@ -79,36 +79,37 @@ const RGE_VAR RGE_P      = {.addr = 13, .name = "p"}; // Unit: GeV
 const RGE_VAR RGE_THETA  = {.addr = 14, .name = "theta"}; // Unit: rad
 const RGE_VAR RGE_PHI    = {.addr = 15, .name = "phi"};  // Unit: rad
 const RGE_VAR RGE_BETA   = {.addr = 16, .name = "beta"};
+const RGE_VAR RGE_TRIGGERSTATUS   = {.addr = 17, .name = "trigger_status"};
 
 /** Tracking variables. */
-const RGE_VAR RGE_CHI2 = {.addr = 17, .name = "chi2"};
-const RGE_VAR RGE_NDF  = {.addr = 18, .name = "NDF"};
+const RGE_VAR RGE_CHI2 = {.addr = 18, .name = "chi2"};
+const RGE_VAR RGE_NDF  = {.addr = 19, .name = "NDF"};
 
 /** Calorimeter variables. */
-const RGE_VAR RGE_PCALE = {.addr = 19, .name = "E_PCAL"}; // Unit: GeV 
-const RGE_VAR RGE_ECINE = {.addr = 20, .name = "E_ECIN"}; // Unit: GeV
-const RGE_VAR RGE_ECOUE = {.addr = 21, .name = "E_ECOU"}; // Unit: GeV
-const RGE_VAR RGE_TOTE  = {.addr = 22, .name = "E_total"}; // Unit: GeV
+const RGE_VAR RGE_PCALE = {.addr = 20, .name = "E_PCAL"}; // Unit: GeV 
+const RGE_VAR RGE_ECINE = {.addr = 21, .name = "E_ECIN"}; // Unit: GeV
+const RGE_VAR RGE_ECOUE = {.addr = 22, .name = "E_ECOU"}; // Unit: GeV
+const RGE_VAR RGE_TOTE  = {.addr = 23, .name = "E_total"}; // Unit: GeV
 
 /** Scintillator variables. */
-const RGE_VAR RGE_DTOF = {.addr = 23, .name = "Delta_TOF"}; // Unit: ns
+const RGE_VAR RGE_DTOF = {.addr = 24, .name = "Delta_TOF"}; // Unit: ns
 
 /** Cherenkov counters variables. */
-const RGE_VAR RGE_NPHELTCC = {.addr = 24, .name = "Nphe_LTCC"};
-const RGE_VAR RGE_NPHEHTCC = {.addr = 25, .name = "Nphe_HTCC"};
+const RGE_VAR RGE_NPHELTCC = {.addr = 25, .name = "Nphe_LTCC"};
+const RGE_VAR RGE_NPHEHTCC = {.addr = 26, .name = "Nphe_HTCC"};
 
 /** DIS variables. */
-const RGE_VAR RGE_Q2 = {.addr = 26, .name = "Q2"}; // Unit: GeV^2
-const RGE_VAR RGE_NU = {.addr = 27, .name = "nu"}; // Unit: GeV
-const RGE_VAR RGE_XB = {.addr = 28, .name = "x_bjorken"};
-const RGE_VAR RGE_YB = {.addr = 29, .name = "y_bjorken"};
-const RGE_VAR RGE_W2 = {.addr = 30, .name = "W2"}; // Unit: GeV
+const RGE_VAR RGE_Q2 = {.addr = 27, .name = "Q2"}; // Unit: GeV^2
+const RGE_VAR RGE_NU = {.addr = 28, .name = "nu"}; // Unit: GeV
+const RGE_VAR RGE_XB = {.addr = 29, .name = "x_bjorken"};
+const RGE_VAR RGE_YB = {.addr = 30, .name = "y_bjorken"};
+const RGE_VAR RGE_W2 = {.addr = 31, .name = "W2"}; // Unit: GeV
 
 /** SIDIS variables. */
-const RGE_VAR RGE_ZH      = {.addr = 31, .name = "z_h"};
-const RGE_VAR RGE_PT2     = {.addr = 32, .name = "p_T2"}; // Unit: GeV^2
-const RGE_VAR RGE_PL2     = {.addr = 33, .name = "p_L2"}; // Unit: GeV^2
-const RGE_VAR RGE_PHIPQ   = {.addr = 34, .name = "phi_PQ"}; // Unit: rad
-const RGE_VAR RGE_THETAPQ = {.addr = 35, .name = "theta_PQ"}; // Unit: rad
+const RGE_VAR RGE_ZH      = {.addr = 32, .name = "z_h"};
+const RGE_VAR RGE_PT2     = {.addr = 33, .name = "p_T2"}; // Unit: GeV^2
+const RGE_VAR RGE_PL2     = {.addr = 34, .name = "p_L2"}; // Unit: GeV^2
+const RGE_VAR RGE_PHIPQ   = {.addr = 35, .name = "phi_PQ"}; // Unit: rad
+const RGE_VAR RGE_THETAPQ = {.addr = 36, .name = "theta_PQ"}; // Unit: rad
 
 #endif

--- a/src/rge_constants.c
+++ b/src/rge_constants.c
@@ -18,7 +18,7 @@
 // --+ library +----------------------------------------------------------------
 const char *RGE_VARS[RGE_VARS_SIZE] = {
         RGE_RUNNO.name, RGE_EVENTNO.name, RGE_BEAME.name,
-        RGE_PID.name, RGE_STATUS.name, RGE_CHARGE.name, RGE_MASS.name,
+        RGE_PID.name, RGE_CHARGE.name, RGE_STATUS.name, RGE_MASS.name,
                 RGE_VX.name, RGE_VY.name, RGE_VZ.name, RGE_PX.name, RGE_PY.name,
                 RGE_PZ.name, RGE_P.name, RGE_THETA.name, RGE_PHI.name,
                 RGE_BETA.name, RGE_TRIGGERSTATUS.name,

--- a/src/rge_constants.c
+++ b/src/rge_constants.c
@@ -21,7 +21,7 @@ const char *RGE_VARS[RGE_VARS_SIZE] = {
         RGE_PID.name, RGE_STATUS.name, RGE_CHARGE.name, RGE_MASS.name,
                 RGE_VX.name, RGE_VY.name, RGE_VZ.name, RGE_PX.name, RGE_PY.name,
                 RGE_PZ.name, RGE_P.name, RGE_THETA.name, RGE_PHI.name,
-                RGE_BETA.name,
+                RGE_BETA.name, RGE_TRIGGERSTATUS.name,
         RGE_CHI2.name, RGE_NDF.name,
         RGE_PCALE.name, RGE_ECINE.name, RGE_ECOUE.name, RGE_TOTE.name,
         RGE_DTOF.name,

--- a/src/rge_particle.c
+++ b/src/rge_particle.c
@@ -283,7 +283,6 @@ int rge_set_pid(
                 e_check, htcc_signal_check, htcc_pion_threshold
         )) return 1;
     }
-
     // Check if particle is trigger electron and define mass from PID.
     particle->is_trigger = (particle->pid == 11 && status < 0);
     if (rge_get_mass(particle->pid, &(particle->mass))) return 1;
@@ -306,7 +305,6 @@ int rge_fill_ntuples_arr(
     arr[RGE_RUNNO.addr]   = static_cast<Float_t>(run_no);
     arr[RGE_EVENTNO.addr] = static_cast<Float_t>(evn);
     arr[RGE_BEAME.addr]   = beam_E;
-
     // Particle.
     arr[RGE_PID.addr]    = static_cast<Float_t>(p.pid);
     arr[RGE_CHARGE.addr] = p.charge;
@@ -322,6 +320,7 @@ int rge_fill_ntuples_arr(
     arr[RGE_THETA.addr]  = theta_lab(p);
     arr[RGE_PHI.addr]    = phi_lab(p);
     arr[RGE_BETA.addr]   = p.beta;
+    arr[RGE_TRIGGERSTATUS.addr] = p.is_trigger;
 
     // Tracking.
     arr[RGE_CHI2.addr] = chi2;

--- a/tuple_multiple_files.sh
+++ b/tuple_multiple_files.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 data_directory=(/volatile/clas12/rg-e/production/calib/v1/calib/recon/020046/*)
-working_directory=/work/clas12/rmilton/backup-clas12-rge-analysis
+working_directory=.
 num_files=573
 run_num=020046
 for FILE in "${data_directory[@]::${num_files}}"


### PR DESCRIPTION
The `status` variable was being saved in the `charge` output. This PR fixes that. 
It was also difficult to differentiate the scattered electron from the other particles in the output file, so the `trigger_status` variable is introduced, with `trigger_status==1` being the scattered electron.